### PR TITLE
feat(openai): omit temperature for GPT-5 models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lucavb/aicommits",
-    "version": "0.6.0",
+    "version": "0.11.1",
     "description": "✨ AI-powered git commit message generator that writes meaningful, consistent commit messages for you. Save time and maintain a clean git history effortlessly.",
     "keywords": [
         "ai",


### PR DESCRIPTION
* update package.json version to 0.11.1 to meet npm repo 0.11.0 version
* introduce modelSupportsCustomTemperature helper in OpenAIProvider to identify models that do not support custom temperature values
* add conditional inclusion of temperature in generateCompletion based on modelSupportsCustomTemperature(params.model)
* add conditional inclusion of temperature in streamCompletion based on modelSupportsCustomTemperature(params.model)
* add test should omit temperature for GPT-5 models that do not support custom values in OpenAIProvider.spec.ts for generation
* add test should omit temperature for GPT-5 models during streaming in OpenAIProvider.spec.ts
* add test should throw an error if generating completion fails in OpenAIProvider.spec.ts